### PR TITLE
feat(contact-form): adding an ajax based netlify form submission

### DIFF
--- a/pages/components/core/organisms/MastHead.js
+++ b/pages/components/core/organisms/MastHead.js
@@ -42,8 +42,8 @@ const Component = (props) => {
       <LogoPlacementColumn hideLogo={props.hideLogo}>
         <LogoText>Morgan Craft</LogoText>
       </LogoPlacementColumn>
-      <NavMenuPlacement>
 
+      <NavMenuPlacement>
         {<NavMenu selected={props.selected} />}
       </NavMenuPlacement>
     </TopBar>


### PR DESCRIPTION
## Context

Watched a youtube overview of using Lambda (node-mailer) to send email.  But we can also leverage the fact Netlify has a form capture piece.  We get 100 form captures a month on the free plan.  And we can from the Netlify panel configure it to forward the message to email/slack.

__Resource__
- [Youtube: Netlify Forms](https://www.youtube.com/watch?v=6ElQ689HRcY) from Traversy Media
- [Netlify Docs: JS Forms](https://docs.netlify.com/forms/setup/#work-with-javascript-rendered-forms)
- [Netlify Docs: Js Forms in React, for nextjs/static-sites there are specific instructions](https://www.netlify.com/blog/2017/07/20/how-to-integrate-netlifys-form-handling-in-a-react-app/?_ga=2.145624881.420250683.1609516755-1149651873.1602754255#form-handling-with-static-site-generators)

## Actions

- First wired up the basic rules for a _netlify form_ add the `<form data-netlify='true' />`
- During wiring decided to go the distance and use react-hooks/state to manage the form and do an ajax based submission.
- Unclear if form submissions with work on preview builds something to test
