### PR TITLE
feat(ga): adding my google analytics package back into play

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_GA=''

--- a/package-lock.json
+++ b/package-lock.json
@@ -3362,6 +3362,15 @@
         }
       }
     },
+    "next-ga": {
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/next-ga/-/next-ga-2.3.4.tgz",
+      "integrity": "sha512-mIol83ehPCz9Z+QtK6ig1w9Db4ShoyhjS6NgDnTIVJuBQ1iobiZap2xXn6KtYWBc+AH5DdTCBtZRF8PP5yJAVA==",
+      "requires": {
+        "debug": "^4.0.0",
+        "react-ga": "^2.5.3"
+      }
+    },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
@@ -4069,6 +4078,11 @@
         "object-assign": "^4.1.1",
         "scheduler": "^0.20.1"
       }
+    },
+    "react-ga": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
+      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "next": "10.0.2",
+    "next-ga": "^2.3.4",
     "react": "17.0.1",
     "react-dom": "17.0.1",
     "styled-components": "^5.2.1"

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,7 +1,10 @@
 import '../styles/globals.css'
 import { ThemeProvider } from 'styled-components'
-
 import { THEME } from '../themeConstants'
+
+// To activate GA & Router
+import Router from 'next/router'
+import withGA from 'next-ga'
 
 function MyApp ({ Component, pageProps }) {
   return (
@@ -12,4 +15,7 @@ function MyApp ({ Component, pageProps }) {
   )
 }
 
-export default MyApp
+// pass your GA code as first argument
+const appComposedWithGA = withGA(process.env.NEXT_PUBLIC_GA, Router)(MyApp)
+
+export default appComposedWithGA


### PR DESCRIPTION
## Story

🔒 [Clubhouse #129](https://app.clubhouse.io/mganlabs/story/129/create-or-upgrade-the-existing-google-analytics) 

## Context

Adding Google-Analytics tracking into the site so I can see my visitor count and not have to pay Netlify their $9 bucks a month for analytics.

GA has moved to GA4, at this time I'm not making the migration and will continue to use what they now call the legacy tracking code as _universal trackers_. 

## Implementation

Another note is the [next-ga](https://github.com/sergiodxa/next-ga) was archived as NextJS community is making their own version.  However, it is not release ready or documented.  Best to stick with this solution for now pending their general-release.

Made decision to place the `env` to be controlled by our deployment and not inside of `next.config.js`.
