### PR TITLE
feat(theme): updating font/type and adopting theme-provider

### DIFF
--- a/pages/components/core/atoms/Badge.js
+++ b/pages/components/core/atoms/Badge.js
@@ -15,7 +15,7 @@ const BadgeFrame = styled.div`
     padding-right: .2em;
   }
   span {
-    font-family: 'Roboto Slab';
+    font-family: ${props => props.theme.fonts.primaryHeader};
       color: #25716D;
   }
 `

--- a/pages/components/core/atoms/Button.js
+++ b/pages/components/core/atoms/Button.js
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 
 // Lora Bold Italic
 const Button = styled.a`
-  font-family: 'Lora', serif;
+  font-family: ${props => props.theme.fonts.accent};
   font-size: 1.3em;
   letter-spacing: .3px;
   font-weight: 700;

--- a/pages/components/core/atoms/LogoText.js
+++ b/pages/components/core/atoms/LogoText.js
@@ -2,7 +2,7 @@ import React from 'react'
 import styled from 'styled-components'
 
 const LogoText = styled.h1`
-  font-family: 'Roboto Slab';
+  font-family: ${props => props.theme.fonts.primaryHeader};
   font-size: 2.5rem;
   position: relative;
   top: 5px;

--- a/pages/components/core/atoms/SectionHeader.js
+++ b/pages/components/core/atoms/SectionHeader.js
@@ -5,7 +5,7 @@ import styled from 'styled-components'
 // Roboto Slab Bold
 const SectionHeader = styled.h2`
   color: #333;
-  font-family: 'Roboto Slab';
+  font-family: ${props => props.theme.fonts.primaryHeader};
   text-align:left;
   font-size:1.7em;
 

--- a/pages/components/core/molecules/NavMenu.js
+++ b/pages/components/core/molecules/NavMenu.js
@@ -18,7 +18,7 @@ const NavLink = styled.a`
   border-bottom: ${props => props.isSelected ? '3px solid #50BEB8' : 'none'};
   font-size: 1.2em;
   
-  font-family: 'Roboto Slab';
+  font-family: ${props => props.theme.fonts.primaryHeader};
   font-weight: 600;
   color: #000;
   text-decoration: none;

--- a/pages/components/core/molecules/ServiceExampleActivities.js
+++ b/pages/components/core/molecules/ServiceExampleActivities.js
@@ -27,8 +27,8 @@ const Frame = styled.div`
   
     font-size: 1.3em;
     color: #0C0524;
-    font-family: 'Lato', sans-serif;
-    font-weight: 300;
+    font-family: ${props => props.theme.fonts.body};
+    font-weight: 200;
     text-indent: -5px;
     line-height: 1.3em;
     margin: 0;
@@ -53,7 +53,7 @@ const Frame = styled.div`
 const ServiceCopy = styled.p`
   font-size: 1.4em;
   color: #000;
-  font-family: 'Lato', sans-serif;
+  font-family: ${props => props.theme.fonts.body};
   font-weight: 400;
   padding: .4em 0;
   line-height: 1.3em;
@@ -62,7 +62,7 @@ const ServiceCopy = styled.p`
 
 // Lora Regular Italic
 const ServiceExampleLabel = styled.span`
-  font-family: 'Lora', serif;
+  font-family: ${props => props.theme.fonts.accent};
   color: #626F90;
   font-weight: 500;
   font-style: italic;
@@ -80,7 +80,7 @@ const ActivityController = styled.div`
 `
 
 const ToggleItem = styled.span`
-font-family: 'Lora', serif;
+font-family: ${props => props.theme.fonts.accent};
 margin: 0 .4em;
 font-size: 1.3em;
 letter-spacing: .3px;

--- a/pages/components/core/molecules/ServiceExampleActivities.js
+++ b/pages/components/core/molecules/ServiceExampleActivities.js
@@ -25,7 +25,7 @@ const Frame = styled.div`
   /* setting dashed list -- https://stackoverflow.com/questions/3200249/html-list-style-type-dash */
   ul li {
   
-    font-size: 1em;
+    font-size: 1.3em;
     color: #0C0524;
     font-family: 'Lato', sans-serif;
     font-weight: 300;

--- a/pages/components/core/molecules/ServiceHeader.js
+++ b/pages/components/core/molecules/ServiceHeader.js
@@ -6,7 +6,7 @@ import PropTypes from 'prop-types'
 import ContentDash from '../atoms/ContentDash'
 
 const Header = styled.h3`
-  font-family: 'Source Sans Pro', serif;
+  font-family: ${props => props.theme.fonts.secondaryHeader};
   font-size: 1.3em;
   margin: 0;
   padding:0 .6em 0 0;
@@ -39,7 +39,7 @@ const ServiceByline = styled.div`
   
   padding-left:.6em;
   font-size:.9em;
-  font-family: 'Lato', sans-serif;
+  font-family: ${props => props.theme.fonts.accent};
   font-weight: 400;
   padding-top:.40em;
   flex-direction: column;

--- a/pages/components/core/organisms/ContactBlock.js
+++ b/pages/components/core/organisms/ContactBlock.js
@@ -21,7 +21,7 @@ const RadioDefinition = styled.dd`
 
 const FieldLabel = styled.span`
   color: #626F90;
-  font-family: 'Lora', serif;
+  font-family: ${props => props.theme.fonts.accent};
   font-weight: 500;
   font-style: italic;
   font-size:1.4em;
@@ -31,7 +31,7 @@ const FieldLabel = styled.span`
 
 const RadioTextLabel = styled.span`
   color: #000;
-  font-family: 'Lora', serif;
+  font-family: ${props => props.theme.fonts.accent};
   font-weight: 500;
   font-style: italic;
   font-size:1.3em;
@@ -94,7 +94,7 @@ const InputDefinition = styled.dd`
       width: 80%;
       color: #989898;
   
-      font-family: 'Lora', serif;
+    font-family: ${props => props.theme.fonts.accent};
     font-weight: 500;
     font-style: italic;
     font-size:1.3em;

--- a/pages/components/core/organisms/Footer.js
+++ b/pages/components/core/organisms/Footer.js
@@ -7,7 +7,7 @@ import ContentFrame from '../templates/ContentFrame'
 
 const BrandingText = styled.p`
 color: #3B4B4A;
-font-family: 'Roboto Slab', serif;
+font-family: ${props => props.theme.fonts.primaryHeader};
 font-weight: 500;
 margin: 0;
 padding: 0;
@@ -17,7 +17,7 @@ text-align:left;
 
 const Text = styled.p`
 color: #3B4B4A;
-font-family: 'Roboto Slab', serif;
+font-family: ${props => props.theme.fonts.primaryHeader};
 font-weight: 500;
 margin: 0;
 padding: 0;

--- a/pages/components/core/organisms/HeroBlock.js
+++ b/pages/components/core/organisms/HeroBlock.js
@@ -33,7 +33,7 @@ const StandardBlock = styled.div`
 
 // Styling the hero text atoms
 const HeroOpeningGreeting = styled.div`
-  font-family: 'Lato';
+  font-family: ${props => props.theme.fonts.body};
   color: #ffffff;
   display:flex;
   position: relative;
@@ -100,7 +100,7 @@ const LargeProfileImage = styled.img`
 
 const HeroName = styled.h2`
   color: #50BEB8;
-  font-family: 'Roboto Slab', serif;
+  font-family: ${props => props.theme.fonts.primaryHeader};
   font-weight: 700;
   font-size:4em;
   padding: 0 0 .1em 0;
@@ -111,7 +111,7 @@ const HeroName = styled.h2`
 
 const HeroObjective = styled.p`
   color: #ffffff;
-  font-family: 'Source Sans Pro', sans-serif;
+  font-family: ${props => props.theme.fonts.secondaryHeader};
   font-size:2.0em;
   
   padding: 0;
@@ -126,7 +126,7 @@ const HeroObjective = styled.p`
 // Lato -- Light
 const Text = styled.span`
   color: #ffffff;
-  font-family: 'Lato', sans-serif;
+  font-family: ${props => props.theme.fonts.accent};
   font-size: 2.6em;
   font-weight: 300;
   padding: 0;
@@ -142,7 +142,7 @@ const HeroDefinitionList = styled.dl`
 // Lora Medium Italics
 const HeroTopic = styled.dt`
   color: #8D8C92;
-  font-family: 'Lora', serif;
+  font-family: ${props => props.theme.fonts.accent};
   font-weight: 500;
   font-style: italic;
   font-size:1.5em;
@@ -158,7 +158,7 @@ const HeroTopic = styled.dt`
 
 const HeroTopicDefinition = styled.dd`
   color: #ffffff;
-  font-family: 'Roboto Slab', serif;
+  font-family: ${props => props.theme.fonts.primaryHeader};
   font-weight: 500;
   margin: 0;
   padding: 0;

--- a/pages/components/core/organisms/ProjectBlock.js
+++ b/pages/components/core/organisms/ProjectBlock.js
@@ -87,7 +87,7 @@ const RoleDescription = styled.p`
   padding: 0;
   margin: 0 0 .5em 0;
   font-size:1.3em;
-  font-family: Ibm Plex Sans;
+  font-family: IBM Plex Sans;
   font-weight: 100;
   color: #0C0524;
 `

--- a/pages/components/core/organisms/ProjectBlock.js
+++ b/pages/components/core/organisms/ProjectBlock.js
@@ -87,7 +87,7 @@ const RoleDescription = styled.p`
   padding: 0;
   margin: 0 0 .5em 0;
   font-size:1.3em;
-  font-family: IBM Plex Sans;
+  font-family: ${props => props.theme.fonts.body};
   font-weight: 100;
   color: #0C0524;
 `

--- a/pages/components/core/organisms/ProjectBlock.js
+++ b/pages/components/core/organisms/ProjectBlock.js
@@ -87,6 +87,9 @@ const RoleDescription = styled.p`
   padding: 0;
   margin: 0 0 .5em 0;
   font-size:1.3em;
+  font-family: Ibm Plex Sans;
+  font-weight: 100;
+  color: #0C0524;
 `
 
 const ProjectBlock = (props) => {

--- a/pages/components/core/organisms/QuoteBlock.js
+++ b/pages/components/core/organisms/QuoteBlock.js
@@ -30,7 +30,7 @@ const QuoteContainer = styled.div`
     color: #fff;
     font-size: 1.8em;
 
-    font-family: 'Lora', serif;
+    font-family: ${props => props.theme.fonts.accent};
     font-weight: 500;
     font-style: italic;
     text-align:center;
@@ -53,7 +53,7 @@ const QuoteContainer = styled.div`
 const QuoteTickStart = styled.span`
   color: #ccc;
     font-size: 2em;
-    font-family: 'Lora', serif;
+    font-family: ${props => props.theme.fonts.accent};
     font-weight: 700;
     letter-spacing:.04em;
 

--- a/pages/components/core/organisms/ServiceBlock.js
+++ b/pages/components/core/organisms/ServiceBlock.js
@@ -34,7 +34,7 @@ const Frame = styled.div`
 const ServiceCopy = styled.p`
   font-size: 1.1em;
   color: #0c0524;
-  font-family: 'Lato', sans-serif;
+  font-family: ${props => props.theme.fonts.body};
   font-weight: 300;
   padding: .6em .1em;
   line-height: 1.5em;

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,7 +62,7 @@ export default function Home () {
         {/* Provided by g-font in recent embed tool, think this helps cdn cache the fonts */}
         <link rel='preconnect' href='https://fonts.gstatic.com' />
         {/* Pair down the font-glyphs post design, don't need all weights */}
-        <link href='https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Roboto+Slab:wght@100;300;500;700&family=Lato:wght@100;400;700&family=Source+Sans+Pro:wght@700&family=IBM+Plex+Sans:wght@100;400&display=swap' rel='stylesheet' />
+        <link href='https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Roboto+Slab:wght@100;300;500;700&family=Source+Sans+Pro:wght@700&family=IBM+Plex+Sans:wght@100;200;300;400;500;600;700&display=swap' rel='stylesheet' />
 
       </Head>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,7 +62,7 @@ export default function Home () {
         {/* Provided by g-font in recent embed tool, think this helps cdn cache the fonts */}
         <link rel='preconnect' href='https://fonts.gstatic.com' />
         {/* Pair down the font-glyphs post design, don't need all weights */}
-        <link href='https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Roboto+Slab:wght@100;300;500;700&family=Lato:wght@100;400;700&family=Source+Sans+Pro:wght@700&display=swap' rel='stylesheet' />
+        <link href='https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Roboto+Slab:wght@100;300;500;700&family=Lato:wght@100;400;700&family=Source+Sans+Pro:wght@700&IBM+Plex+Sans:wght@100;400&display=swap' rel='stylesheet' />
 
       </Head>
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -62,7 +62,7 @@ export default function Home () {
         {/* Provided by g-font in recent embed tool, think this helps cdn cache the fonts */}
         <link rel='preconnect' href='https://fonts.gstatic.com' />
         {/* Pair down the font-glyphs post design, don't need all weights */}
-        <link href='https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Roboto+Slab:wght@100;300;500;700&family=Lato:wght@100;400;700&family=Source+Sans+Pro:wght@700&IBM+Plex+Sans:wght@100;400&display=swap' rel='stylesheet' />
+        <link href='https://fonts.googleapis.com/css2?family=Lora:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&family=Roboto+Slab:wght@100;300;500;700&family=Lato:wght@100;400;700&family=Source+Sans+Pro:wght@700&family=IBM+Plex+Sans:wght@100;400&display=swap' rel='stylesheet' />
 
       </Head>
 

--- a/themeConstants.js
+++ b/themeConstants.js
@@ -7,12 +7,22 @@ export const PRIMARY_BRAND = '#50BEB8'
 // think of a the Primary-d2/3
 export const PRIMARY_BRAND_D2 = '#25716D'
 
+export const FONT_FAMILY_ROBOTO_SLAB = 'Roboto Slab, serif'
+export const FONT_FAMILY_SOURCE_SANS_PRO = 'Source Sans Pro, sans-serif'
+export const FONT_FAMILY_LORA_SANS = 'Lora, sans-serif'
+export const FONT_FAMILY_IBM_SANS = 'IBM Plex Sans, sans-serif'
+
 export const THEME = {
+  fonts: {
+    primaryHeader: FONT_FAMILY_ROBOTO_SLAB,
+    secondaryHeader: FONT_FAMILY_SOURCE_SANS_PRO,
+    body: FONT_FAMILY_IBM_SANS,
+    accent: FONT_FAMILY_LORA_SANS
+  },
   colors: {
     primaryBrand: PRIMARY_BRAND,
     primaryBrandD2: PRIMARY_BRAND_D2
   }
-
 }
 
 export default THEME


### PR DESCRIPTION
## Story

🔒 [Clubhouse #139](https://app.clubhouse.io/mganlabs/story/139/experimenting-with-fonts-and-colors-for-body-copy)

## Context

What began as an experiment to determine which `font-family` to adopt, it evolved to use `IBM Plex Sans` for our __body__.  At which, swapping it between the various components it was time to begin using the `theme-provider` that was already provisioned earlier on.

## Implementation Details

First experiment is to add `Ibm Plex Sans` at the same `color: #0C0524;` and just get a sense of our base.

> _visual recording on clubhouse story, github won't allow video attachments_

The work evolved to then go `git grep` for various locations where I had originally hacked in various fonts as I was building.  This time around I began using the `theme-provider`.

For the four font types being used I created the following `theme` provider:

```javascript
export const FONT_FAMILY_ROBOTO_SLAB = 'Roboto Slab, serif'
export const FONT_FAMILY_SOURCE_SANS_PRO = 'Source Sans Pro, sans-serif'
export const FONT_FAMILY_LORA_SANS = 'Lora, sans-serif'
export const FONT_FAMILY_IBM_SANS = 'IBM Plex Sans, sans-serif'

export const THEME = {
  fonts: {
    primaryHeader: FONT_FAMILY_ROBOTO_SLAB,
    secondaryHeader: FONT_FAMILY_SOURCE_SANS_PRO,
    body: FONT_FAMILY_IBM_SANS,
    accent: FONT_FAMILY_LORA_SANS
  }
}
```